### PR TITLE
CORE: View a separate page for each topic with a list of related articles

### DIFF
--- a/API.js
+++ b/API.js
@@ -11,15 +11,15 @@ export const getArticles = () => {
 }
 
 
-// export const getArticlesByTopic = (topic) => {
+export const getArticlesByTopic = (topic) => {
 
-//     const query = topic ? `?topic=${topic}` : '';
+    const query = topic ? `?topic=${topic}` : '';
 
-//     return axios
-//         .get(url + `/articles${query}`)
-//         .then((response) => response.data)
-//         .catch((err) => console.log(err));
-// }
+    return axios
+        .get(url + `/articles${query}`)
+        .then((response) => response.data)
+        .catch((err) => console.log(err));
+}
 
 
 export const getArticleTopics = () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,30 +1,30 @@
-import './App.css'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import 'bootstrap/dist/css/bootstrap.min.css'
-import Header from './components/Header'
-import HomePage from './components/HomePage'
-import ArticlesList from './components/ArticlesList'
-import IndividialArticle from './components/IndividualArticle'
-import CommentList from './components/CommentList'
-import { UserProvider } from './components/UserComponent'
+import './App.css';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import Header from './components/Header';
+import HomePage from './components/HomePage';
+import ArticlesList from './components/ArticlesList';
+import IndividualArticle from './components/IndividualArticle';
+import CommentList from './components/CommentList';
+import { UserProvider } from './components/UserComponent';
+import IndividualTopic from './components/IndividualTopic';
 
 function App() {
-
-
   return (
     <UserProvider>
-    <BrowserRouter>
-      <Header />
-      <Routes>
-        <Route path='/' element={<HomePage />} />
-        <Route path='/home' element={<HomePage />} />
-        <Route path='/articles' element={<ArticlesList />} />
-        <Route path='/articles/:article_id' element={<IndividialArticle />} />
-        <Route path='/articles/:article_id' element={<CommentList />} />
-      </Routes>
-    </BrowserRouter>
+      <BrowserRouter>
+        <Header />
+        <Routes>
+          <Route path='/' element={<HomePage />} />
+          <Route path='/home' element={<HomePage />} />
+          <Route path='/articles' element={<ArticlesList />} />
+          <Route path='/articles/:article_id' element={<IndividualArticle />} />
+          <Route path='/articles/:article_id/comments' element={<CommentList />} />
+          <Route path='/topics/:topic' element={<IndividualTopic />} /> 
+        </Routes>
+      </BrowserRouter>
     </UserProvider>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,26 +1,45 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Navbar, Nav, Container, Image } from "react-bootstrap";
+import { Link } from "react-router-dom"; 
 import { UserContext } from "./UserComponent";
+import { getArticleTopics } from "../../API";
 
 const Header = () => {
   const { user } = useContext(UserContext);
+  const [topics, setTopics] = useState([]);
+
+  useEffect(() => {
+    getArticleTopics()
+      .then((topicsResponse) => {
+        setTopics(topicsResponse.topics);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, []);
 
   return (
     <Navbar bg="dark" variant="dark" expand="lg">
       <Container>
-        <Navbar.Brand href="/home">The Code Chronicle</Navbar.Brand>
+        <Navbar.Brand as={Link} to="/home">The Code Chronicle</Navbar.Brand>
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="me-auto">
-            <Nav.Link href="/home">Home</Nav.Link>
-            <Nav.Link href="/articles">Articles</Nav.Link>
+            <Nav.Link as={Link} to="/home">Home</Nav.Link>
+            <Nav.Link as={Link} to="/articles">Articles</Nav.Link>
+            {/* Dynamic Nav.Links for topics */}
+            {topics.map((topic) => (
+              <Nav.Link key={topic.slug} as={Link} to={`/topics/${topic.slug}`}>
+                {topic.slug}
+              </Nav.Link>
+            ))}
           </Nav>
           <Nav>
             <Nav.Link>
-             <Image src={user.avatar_url} roundedCircle width="50" height="50"/>
-            <Navbar.Text className="text-light">
-              User: {user.username}
-            </Navbar.Text>
+              <Image src={user.avatar_url} roundedCircle width="50" height="50" />
+              <Navbar.Text className="text-light">
+                User: {user.username}
+              </Navbar.Text>
             </Nav.Link>
           </Nav>
         </Navbar.Collapse>

--- a/src/components/IndividualTopic.jsx
+++ b/src/components/IndividualTopic.jsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { Container, Spinner, Alert, Row, Col, Card } from 'react-bootstrap';
+import { getArticlesByTopic } from '../../API';
+
+
+
+const IndividualTopic = () => {
+
+  const { topic } = useParams();
+  const [isLoading, setIsLoading] = useState(true);
+  const [articles, setArticles] = useState([]);
+
+  useEffect(() => {
+    setIsLoading(true);
+
+    getArticlesByTopic(topic)
+      .then((articlesResponse) => {
+        setArticles(articlesResponse.articles);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        console.log(err);
+        setIsLoading(false);
+      });
+  }, [topic]);
+
+
+  if (isLoading) {
+    return (
+      <Container className="d-flex justify-content-center align-items-center" style={{ minHeight: '100vh' }}>
+        <Spinner animation="border" role="status">
+          <span className="visually-hidden">Loading...</span>
+        </Spinner>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <h1 className="articles-list">Articles {topic && `in ${topic}`}</h1>
+  <Row xs={1} md={2} lg={3} className="g-4">
+                {articles.map(article => (
+                    <Col key={article.article_id}>
+                        <Link to={`/articles/${article.article_id}`} className="link">
+                            <Card>
+                                {article.article_img_url && <Card.Img variant="top" src={article.article_img_url} />}
+                                <Card.Body>
+                                    <Card.Title>{article.title}</Card.Title>
+                                    <Card.Text>
+                                        <strong>Author:</strong> {article.author} <strong className="votes">Votes:</strong> {article.votes}
+                                    </Card.Text>
+                                </Card.Body>
+                            </Card>
+                        </Link>
+                    </Col>
+                ))}
+            </Row>
+    </Container>
+  );
+};
+
+export default IndividualTopic;


### PR DESCRIPTION
Had to go back on myself here due to misunderstanding of the ticket, now added a new 'IndividualTopic' component to render a new page of jsut articles from that topic via the getArticlesByTopic API. Also updated the Header Links with a map to display topics dynamically. 